### PR TITLE
Fields to Account and state param for work

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
 	key := "<YOUR API KEY>"
 
 	// create the client
-	client := lytics.NewLytics(key, nil)
+	client := lytics.NewLytics(key, nil, nil)
 
 	// list all accounts for key
 	accounts, err := client.GetAccounts()

--- a/account.go
+++ b/account.go
@@ -18,6 +18,8 @@ type Account struct {
 	Aid              int       `json:"aid"`
 	ParentAid        int       `json:"parentaid"`
 	ParentId         string    `json:"parent_id"`
+	PartnerId        string    `json:"partner_id"`
+	PackageId        string    `json:"package_id"`
 	Email            string    `json:"email"`
 	ApiKey           string    `json:"apikey"`
 	DataApiKey       string    `json:"dataapikey"`

--- a/account_test.go
+++ b/account_test.go
@@ -12,7 +12,7 @@ func TestGetAccounts(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterAccountMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	accts, err := client.GetAccounts()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(accts) > 1)
@@ -23,7 +23,7 @@ func TestGetAccount(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterAccountMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	acct, err := client.GetAccount(mock.MockAccountID)
 	assert.Equal(t, err, nil)
 	assert.T(t, acct.Id == mock.MockAccountID)

--- a/auth_test.go
+++ b/auth_test.go
@@ -12,7 +12,7 @@ func TestGetAuths(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterAuthMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	auths, err := client.GetAuths()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(auths) > 1)
@@ -23,7 +23,7 @@ func TestGetAuth(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterAuthMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	auth, err := client.GetAuth(mock.MockAuthID)
 	assert.Equal(t, err, nil)
 	assert.T(t, auth.Id == mock.MockAuthID)

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -12,7 +12,7 @@ func TestGetSchema(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterCatalogMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	data, err := client.GetSchema("user")
 
 	assert.Equal(t, err, nil)

--- a/cmd/lytics/catalog.go
+++ b/cmd/lytics/catalog.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 )
 
-func (c *Cli) getSchema(table string, limit int) (interface{}, error) {
+func (c *Cli) getSchema(table string) (interface{}, error) {
 	if table == "" {
 		return nil, errors.New("Missing '-table' (e.g. user, content).")
 	}
 
-	schema, err := c.Client.GetSchema(table, limit)
+	schema, err := c.Client.GetSchema(table)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/lytics/main.go
+++ b/cmd/lytics/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	// estblish cli client
 	c := Cli{
-		Client: lytics.NewLytics(apikey, dataapikey),
+		Client: lytics.NewLytics(apikey, dataapikey, nil),
 	}
 
 	output, err := c.handleFunction(method)
@@ -125,7 +125,7 @@ func (c *Cli) handleFunction(method string) (string, error) {
 		result, err = c.getAuths(id)
 
 	case "schema":
-		result, err = c.getSchema(table, limit)
+		result, err = c.getSchema(table)
 
 	case "entity":
 		result, err = c.getEntity(entitytype, fieldname, fieldvalue, fieldsSlice)

--- a/cmd/lytics/segment.go
+++ b/cmd/lytics/segment.go
@@ -37,7 +37,7 @@ func (c *Cli) getSegmentSizes(segments []string) (interface{}, error) {
 }
 
 func (c *Cli) getSegmentAttributions(segments []string, limit int) (interface{}, error) {
-	attributions, err := c.Client.GetSegmentAttribution(segments, limit)
+	attributions, err := c.Client.GetSegmentAttribution(segments)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/lytics/work.go
+++ b/cmd/lytics/work.go
@@ -2,7 +2,7 @@ package main
 
 func (c *Cli) getWorks(id interface{}) (interface{}, error) {
 	if id != nil && id != "" {
-		work, err := c.Client.GetWork(id.(string))
+		work, err := c.Client.GetWork(id.(string), false)
 		if err != nil {
 			return nil, err
 		}

--- a/content_test.go
+++ b/content_test.go
@@ -12,7 +12,7 @@ func TestGetUserContentRecommendation(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterContentMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	recs, err := client.GetUserContentRecommendation("user_id", mock.MockUserID, "", 1, false)
 
 	assert.Equal(t, err, nil)

--- a/entity_test.go
+++ b/entity_test.go
@@ -12,7 +12,7 @@ func TestGetEntity(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterEntityMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 
 	fields := []string{}
 	entitytype := "user"

--- a/examples/get_accounts.md
+++ b/examples/get_accounts.md
@@ -14,7 +14,7 @@ func main() {
 	key := "<YOUR API KEY>"
 
 	// create the client
-	client := lytics.NewLytics(key, nil)
+	client := lytics.NewLytics(key, nil, nil)
 
 	// list all accounts for key
 	accounts, err := client.GetAccounts()

--- a/examples/get_segments.md
+++ b/examples/get_segments.md
@@ -14,7 +14,7 @@ func main() {
 	key := "<YOUR API KEY>"
 
 	// create the client
-	client := lytics.NewLytics(key, nil)
+	client := lytics.NewLytics(key, nil, nil)
 
 	// list all accounts for key
 	segments, err := client.GetSegments()

--- a/examples/get_segments_for_user.md
+++ b/examples/get_segments_for_user.md
@@ -16,7 +16,7 @@ func main() {
 	fieldval := "<YOUR FIELD VALUE>"   // value of the field
 
 	// create the client
-	client := lytics.NewLytics(key, nil)
+	client := lytics.NewLytics(key, nil, nil)
 
 	// list all accounts for key
 	entity, err := client.GetEntity(entitytype, fieldname, fieldval, nil)

--- a/examples/page_through_segment.md
+++ b/examples/page_through_segment.md
@@ -17,7 +17,7 @@ func main() {
 	segmentid := "<YOUR SEGMENT ID HERE>"
 
 	// create the client
-	client := lytics.NewLytics(apikey, nil)
+	client := lytics.NewLytics(apikey, nil, nil)
 
 	// create the segment scanner
 	err = client.CreateScanner()

--- a/provider_test.go
+++ b/provider_test.go
@@ -12,7 +12,7 @@ func TestGetProviders(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterProviderMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	provider, err := client.GetProviders()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(provider) > 1)
@@ -23,7 +23,7 @@ func TestGetProvider(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterProviderMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	provider, err := client.GetProvider(mock.MockProviderID)
 	assert.Equal(t, err, nil)
 	assert.T(t, provider.Id == mock.MockProviderID)

--- a/segment_test.go
+++ b/segment_test.go
@@ -13,7 +13,7 @@ func TestGetSegments(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterSegmentMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	segs, err := client.GetSegments()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(segs) > 1)
@@ -24,7 +24,7 @@ func TestGetSegment(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterSegmentMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	seg, err := client.GetSegment(mock.MockSegmentID1)
 	assert.Equal(t, err, nil)
 	assert.T(t, seg.Id == mock.MockSegmentID1)
@@ -35,7 +35,7 @@ func TestGetSegmentSize(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterSegmentMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	seg, err := client.GetSegmentSize(mock.MockSegmentID1)
 
 	assert.Equal(t, err, nil)
@@ -49,7 +49,7 @@ func TestGetSegmentSizes(t *testing.T) {
 
 	var segments []string
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 
 	segments = []string{
 		mock.MockSegmentID1,
@@ -80,7 +80,7 @@ func TestGetSegmentAttribution(t *testing.T) {
 		mock.MockSegmentID2,
 	}
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	attr, err := client.GetSegmentAttribution(segments)
 
 	assert.Equal(t, err, nil)
@@ -99,7 +99,7 @@ func TestSegmentPager(t *testing.T) {
 		countEntities int
 	)
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 
 	// create the segment scanner
 	err := client.CreateScanner()

--- a/user_test.go
+++ b/user_test.go
@@ -12,7 +12,7 @@ func TestGetUsers(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterUserMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	users, err := client.GetUsers()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(users) > 1)
@@ -23,7 +23,7 @@ func TestGetUser(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterUserMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	user, err := client.GetUser(mock.MockUserID)
 	assert.Equal(t, err, nil)
 	assert.T(t, user.Id == mock.MockUserID)

--- a/work.go
+++ b/work.go
@@ -2,11 +2,12 @@ package lytics
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 )
 
 const (
-	workEndpoint     = "work/:id"
+	workEndpoint     = "work/:id" // state
 	workListEndpoint = "work"
 )
 
@@ -30,12 +31,12 @@ type Work struct {
 
 // GetWork returns a single work
 // https://www.getlytics.com/developers/rest-api#work-get
-func (l *Client) GetWork(id string) (Work, error) {
+func (l *Client) GetWork(id string, state bool) (Work, error) {
 	res := ApiResp{}
 	data := Work{}
 
 	// make the request
-	err := l.Get(parseLyticsURL(workEndpoint, map[string]string{"id": id}), nil, nil, &res, &data)
+	err := l.Get(parseLyticsURL(workEndpoint, map[string]string{"id": id, "state": strconv.FormatBool(state)}), nil, nil, &res, &data)
 	if err != nil {
 		return data, err
 	}

--- a/work_test.go
+++ b/work_test.go
@@ -12,7 +12,7 @@ func TestGetWorks(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterWorkMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
+	client := NewLytics(mock.MockApiKey, nil, nil)
 	work, err := client.GetWorks()
 	assert.Equal(t, err, nil)
 	assert.T(t, len(work) > 1)
@@ -23,8 +23,8 @@ func TestGetWork(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mock.RegisterWorkMocks()
 
-	client := NewLytics(mock.MockApiKey, nil)
-	work, err := client.GetWork(mock.MockWorkID)
+	client := NewLytics(mock.MockApiKey, nil, nil)
+	work, err := client.GetWork(mock.MockWorkID, false)
 	assert.Equal(t, err, nil)
 	assert.T(t, work.Id == mock.MockWorkID)
 }


### PR DESCRIPTION
- Add `partner_id` and `package_id` to account
- Add state param for `GetWork`

All other changes in here a fixing tests, the command line tool, and examples (seems like some were broken since we hadn't updated the call to `NewLytics` to include the client param).
