### PR TITLE
Create, Validate, and Page AdHoc Segment

### DIFF
--- a/examples/get_segments.md
+++ b/examples/get_segments.md
@@ -17,7 +17,7 @@ func main() {
 	client := lytics.NewLytics(key, nil, nil)
 
 	// list all accounts for key
-	segments, err := client.GetSegments()
+	segments, err := client.GetSegments("user")
 	if err != nil {
 		panic(err)
 	}

--- a/lytics.go
+++ b/lytics.go
@@ -178,7 +178,7 @@ func (l *Client) Do(r *http.Request, response, data interface{}) error {
 }
 
 // Get prepares a get request and then executes using the Do method
-func (l *Client) Get(endpoint string, params url.Values, body io.Reader, response, data interface{}) error {
+func (l *Client) Get(endpoint string, params url.Values, body interface{}, response, data interface{}) error {
 	method := "GET"
 
 	// get the formatted endpoint url
@@ -187,8 +187,13 @@ func (l *Client) Get(endpoint string, params url.Values, body io.Reader, respons
 		return err
 	}
 
+	payload, err := prepRequestBody(body)
+	if err != nil {
+		return err
+	}
+
 	// build the request
-	r, _ := http.NewRequest(method, path, body)
+	r, _ := http.NewRequest(method, path, payload)
 
 	// execute the request
 	err = l.Do(r, response, data)
@@ -197,6 +202,54 @@ func (l *Client) Get(endpoint string, params url.Values, body io.Reader, respons
 	}
 
 	return nil
+}
+
+// Get prepares a post request and then executes using the Do method
+func (l *Client) Post(endpoint string, params url.Values, body interface{}, response, data interface{}) error {
+	method := "POST"
+
+	// get the formatted endpoint url
+	path, err := l.PrepUrl(endpoint, params, false)
+	if err != nil {
+		return err
+	}
+
+	payload, err := prepRequestBody(body)
+	if err != nil {
+		return err
+	}
+
+	// build the request
+	r, _ := http.NewRequest(method, path, payload)
+
+	// execute the request
+	err = l.Do(r, response, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prepBodyRequest takes the payload and returns an io.Reader
+func prepRequestBody(body interface{}) (io.Reader, error) {
+	// prep the body of the request
+	if body != nil {
+		if _, ok := body.(string); ok {
+			// plain/text body
+			return strings.NewReader(body), nil
+		} else {
+			// json body
+			b, err := json.Marshal(body)
+			if err != nil {
+				return nil, err
+			}
+
+			return bytes.NewReader(b), nil
+		}
+	}
+
+	return nil, nil
 }
 
 // buildRespJSON handles the first round of unmarshaling into the master Api Response struct

--- a/lytics.go
+++ b/lytics.go
@@ -234,20 +234,19 @@ func (l *Client) Post(endpoint string, params url.Values, body interface{}, resp
 
 // prepBodyRequest takes the payload and returns an io.Reader
 func prepRequestBody(body interface{}) (io.Reader, error) {
-	// prep the body of the request
-	if body != nil {
-		if bodystr, ok := body.(string); ok {
-			// plain/text body
-			return strings.NewReader(bodystr), nil
-		} else {
-			// json body
-			b, err := json.Marshal(body)
-			if err != nil {
-				return nil, err
-			}
 
-			return bytes.NewReader(b), nil
+	switch val := body.(type) {
+	case string:
+		return strings.NewReader(val), nil
+	case nil:
+		return nil, nil
+	default:
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
 		}
+
+		return bytes.NewReader(b), nil
 	}
 
 	return nil, nil

--- a/lytics.go
+++ b/lytics.go
@@ -1,6 +1,7 @@
 package lytics
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -235,9 +236,9 @@ func (l *Client) Post(endpoint string, params url.Values, body interface{}, resp
 func prepRequestBody(body interface{}) (io.Reader, error) {
 	// prep the body of the request
 	if body != nil {
-		if _, ok := body.(string); ok {
+		if bodystr, ok := body.(string); ok {
 			// plain/text body
-			return strings.NewReader(body), nil
+			return strings.NewReader(bodystr), nil
 		} else {
 			// json body
 			b, err := json.Marshal(body)

--- a/mock/json/get_content_segments.json
+++ b/mock/json/get_content_segments.json
@@ -1,0 +1,48 @@
+{
+  "status": 200,
+  "message": "success",
+  "data": [
+    {
+      "aid": 1,
+      "account_id": "224y234ywerhwerhw345y2",
+      "id": "063364ddfa1a43948b36",
+      "short_id": "Short ID",
+      "name": "New Content",
+      "kind": "segment",
+      "is_public": true,
+      "public_name": "new_content",
+      "slug_name": "new_content",
+      "table": "content",
+      "author_id": "a6dsga789dg69adg6a9g22",
+      "updated": "2014-05-13T16:53:20Z",
+      "created": "2014-05-13T16:53:20Z",
+      "invalid": false,
+      "invalid_reason": "",
+      "deleted": false,
+      "save_hist": false,
+      "segment_ql": "FILTER (created >= \"now-30d\")",
+      "tags": []
+    },
+    {
+      "aid": 1,
+      "account_id": "224y234ywerhwerhw345y2",
+      "id": "314be8a3e5f44fc846319",
+      "short_id": "Short ID 2",
+      "name": "Marketing Blog Articles",
+      "kind": "segment",
+      "is_public": true,
+      "public_name": "marketing_blog",
+      "slug_name": "marketing_blog",
+      "table": "content",
+      "author_id": "a6dsga789dg69adg6a9g22",
+      "updated": "2016-09-14T23:01:46.111Z",
+      "created": "2016-02-21T16:56:30.959Z",
+      "invalid": false,
+      "invalid_reason": "",
+      "deleted": false,
+      "save_hist": false,
+      "segment_ql": "FILTER AND (path CONTAINS \"blog/post\", global.Marketing > 0)",
+      "tags": []
+    }
+  ]
+}

--- a/mock/json/post_segment_create.json
+++ b/mock/json/post_segment_create.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "f186a334ad7109bbe08880",
+    "account_id": "224y234ywerhwerhw345y2",
+    "author_id": "a6dsga789dg69adg6a9g22",
+    "kind": "segment",
+    "segment_ql": "FILTER AND (created >= \"now-30d\", aspects = \"articles\") FROM content",
+    "updated": "2014-05-13T16:53:20Z",
+    "created": "2014-05-13T16:53:20Z",
+    "name": "Recent Articles",
+    "slug_name": "recent_articles",
+    "table": "content",
+    "tags": []
+  }
+}

--- a/mock/json/post_segment_create_error.json
+++ b/mock/json/post_segment_create_error.json
@@ -1,0 +1,5 @@
+{
+  "data": null,
+  "message": "Invalid SegmentQL",
+  "status": 400
+}

--- a/mock/json/post_segment_validate.json
+++ b/mock/json/post_segment_validate.json
@@ -1,0 +1,5 @@
+{
+  "status": 200,
+  "message":"success",
+  "data": null
+}

--- a/mock/json/post_segment_validate_error.json
+++ b/mock/json/post_segment_validate_error.json
@@ -1,0 +1,5 @@
+{
+  "data":null,
+  "message":"Failed parsing segment QL Unrecognized Filter Statement: Token{  Type:\"Error\" Line:1 Col:0 Q:\u0000}  ",
+  "status":400
+}

--- a/provider.go
+++ b/provider.go
@@ -26,7 +26,7 @@ func (l *Client) GetProviders() ([]Provider, error) {
 	data := []Provider{}
 
 	// make the request
-	err := l.Get(providerListEndpoint, nil, &res, &data)
+	err := l.Get(providerListEndpoint, nil, nil, &res, &data)
 	if err != nil {
 		return data, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -26,7 +26,7 @@ func (l *Client) GetProviders() ([]Provider, error) {
 	data := []Provider{}
 
 	// make the request
-	err := l.Get(providerListEndpoint, nil, nil, &res, &data)
+	err := l.Get(providerListEndpoint, nil, &res, &data)
 	if err != nil {
 		return data, err
 	}

--- a/segment.go
+++ b/segment.go
@@ -120,7 +120,7 @@ func (l *Client) GetSegment(id string) (Segment, error) {
 
 // GetSegments returns a list of all segments for an account
 // https://www.getlytics.com/developers/rest-api#segment-list
-func (l *Client) GetSegments(string table) ([]Segment, error) {
+func (l *Client) GetSegments(table string) ([]Segment, error) {
 	res := ApiResp{}
 	data := []Segment{}
 	params := url.Values{}
@@ -128,7 +128,7 @@ func (l *Client) GetSegments(string table) ([]Segment, error) {
 	params.Add("table", table)
 
 	// make the request
-	err := l.Get(segmentListEndpoint, params, &res, &data)
+	err := l.Get(segmentListEndpoint, params, nil, &res, &data)
 	if err != nil {
 		return data, err
 	}
@@ -261,7 +261,7 @@ func (l *Client) GetAdHocSegmentEntities(ql, next string, limit int) (interface{
 	params.Add("start", next)
 	params.Add("limit", strconv.Itoa(limit))
 
-	err := l.Get(adHocsegmentScanEndpoint, params, ql, params, &res, &data)
+	err := l.Get(adHocsegmentScanEndpoint, params, ql, &res, &data)
 	if err != nil {
 		return "", "", data, err
 	}
@@ -373,7 +373,7 @@ func (l *Client) CreateSegment(name, ql, slug string) (Segment, error) {
 	payload := Segment{
 		Name:     name,
 		FilterQL: ql,
-		Slug:     slug,
+		SlugName: slug,
 	}
 
 	// make the request
@@ -382,7 +382,7 @@ func (l *Client) CreateSegment(name, ql, slug string) (Segment, error) {
 		return data, err
 	}
 
-	return res.Status, res.Next, data, nil
+	return data, nil
 }
 
 // ValidateSegment validates a single segment QL statement


### PR DESCRIPTION
closes #7 

Adds methods for creating a segment, validating a filter ql statement, and paging an ad hoc segment. These methods should work for segments on both a content and user table.
