### PR TITLE
Fix adhoc segment scan.

### DIFF
--- a/lytics.go
+++ b/lytics.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	u "github.com/araddon/gou"
 )
 
 // Client defines the supported subset of the Lytics API. The Lytics API may contain other features
@@ -284,7 +282,6 @@ func buildRespJSON(b []byte, response, data interface{}) error {
 
 	err = json.Unmarshal(b, response)
 	if err != nil {
-		u.Errorf("Error %v", err)
 		return err
 	}
 
@@ -293,7 +290,6 @@ func buildRespJSON(b []byte, response, data interface{}) error {
 		if len(rt.Data) > 0 {
 			err = json.Unmarshal(rt.Data, &data)
 			if err != nil {
-				u.Warnf("bad data %v  \n\n%s", err, string(rt.Data))
 				return err
 			}
 		}

--- a/segment.go
+++ b/segment.go
@@ -312,7 +312,7 @@ func (l *Client) GetAdHocSegmentEntities(ql, next string, limit int) (interface{
 	params.Add("start", next)
 	params.Add("limit", strconv.Itoa(limit))
 
-	err := l.Get(adHocsegmentScanEndpoint, params, ql, &res, &data)
+	err := l.PostType("text/plain", adHocsegmentScanEndpoint, params, ql, &res, &data)
 	if err != nil {
 		return "", "", data, err
 	}


### PR DESCRIPTION
- Fix Ad-Hoc Segment Scan to use `plain/text` POST request
- Remove `github.com/araddon/gou` import since it uses syscall which is not supported by appengine.