### PR TITLE
Validate query segment

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,6 +1,7 @@
 package lytics
 
 import (
+	"encoding/json"
 	"net/url"
 	"time"
 )
@@ -100,18 +101,30 @@ func (l *Client) PostQueryValidate(query string) ([]Query, error) {
 }
 
 // PostQueryValidateSegment checks query interpretation & validates query against existing segments/ schemas
-func (l *Client) PostQueryValidateSegment(query string) ([]Query, error) {
+func (l *Client) PostQueryValidateSegment(query string) (interface{}, error) {
 	res := ApiResp{}
-	data := []Query{}
+	djson := json.RawMessage{}
 	v := url.Values{}
 	v.Set("segments", "true")
 
 	// make the request
-	err := l.PostType("text/plain", queryValidateEndpoint, v, query, &res, &data)
-
+	err := l.PostType("text/plain", queryValidateEndpoint, v, query, &res, &djson)
+	var data interface{}
+	// unmarshal response `data` field into appropriate type depending on response status & message
+	// add cases?
+	switch res.Status {
+	case float64(400):
+		if res.Message == "Invalid schema errors" {
+			d := []string{}
+			e := json.Unmarshal(djson, &d)
+			if e != nil {
+				return nil, e
+			}
+			data = d
+		}
+	}
 	if err != nil {
 		return data, err
 	}
-
 	return data, nil
 }

--- a/query.go
+++ b/query.go
@@ -85,12 +85,29 @@ func (l *Client) GetQueryTest(qs url.Values, query string) (Entity, error) {
 
 // PostQueryValidate returns the query and how it is interpreted
 // https://www.getlytics.com/developers/rest-api#query
-func (l *Client) PostQueryValidate(query string) (Query, error) {
+func (l *Client) PostQueryValidate(query string) ([]Query, error) {
 	res := ApiResp{}
-	data := Query{}
+	data := []Query{}
 
 	// make the request
 	err := l.PostType("text/plain", queryValidateEndpoint, nil, query, &res, &data)
+
+	if err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// PostQueryValidateSegment checks query interpretation & validates query against existing segments/ schemas
+func (l *Client) PostQueryValidateSegment(query string) ([]Query, error) {
+	res := ApiResp{}
+	data := []Query{}
+	v := url.Values{}
+	v.Set("segments", "true")
+
+	// make the request
+	err := l.PostType("text/plain", queryValidateEndpoint, v, query, &res, &data)
 
 	if err != nil {
 		return data, err


### PR DESCRIPTION
PostQueryValidateSegment sends request to _validate route with parameter to check lql against existing segments. No longer hard-coded to unmarshal response data field to QueryData.