### PR TITLE
testify failures in earlier versions of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
+
 
 before_install:
   - go get -t -v ./...


### PR DESCRIPTION
Updated travis to see if we're still seeing errors

```
$ go version
go version go1.12.17 linux/amd64
go.env
$ go env
before_install
10.09s$ go get -t -v ./...
install
0.20s$ travis_install_go_dependencies 1.12.x -v
5.45s$ travis_script_go -v
# github.com/stretchr/testify/assert
../../stretchr/testify/assert/assertions.go:1725:5: undefined: errors.Is
../../stretchr/testify/assert/assertions.go:1748:6: undefined: errors.Is
../../stretchr/testify/assert/assertions.go:1771:5: undefined: errors.As
../../stretchr/testify/assert/assertions.go:1788:7: undefined: errors.Unwrap
../../stretchr/testify/assert/assertions.go:1792:7: undefined: errors.Unwrap
FAIL	github.com/lytics/go-lytics [build failed]
?   	github.com/lytics/go-lytics/examples/segmentscan	[no test files]
?   	github.com/lytics/go-lytics/mock	[no test files]
The command "go test -v ./..." exited with 2.
```